### PR TITLE
Bug correction, set a moved hash map/set in a valid state so that it can still be used even after a move

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,26 @@ To implement your own policy, you have to implement the following interface.
 
 ```c++
 struct custom_policy {
-    // Called on hash table construction, min_bucket_count_in_out is the minimum size
-    // that the hash table needs. The policy can change it to a higher bucket count if needed
+    // Called on the hash table creation and on rehash. The number of buckets for the table is passed in parameter.
+    // This number is a minimum, the policy may update this value with a higher value if needed (but not lower).
+    //
+    // If 0 is given, min_bucket_count_in_out must still be 0 after the policy creation and
+    // bucket_for_hash must always return 0 in this case.    
     explicit custom_policy(std::size_t& min_bucket_count_in_out);
     
-    // Return the bucket for the corresponding hash
+    // Return the bucket [0, bucket_count()) to which the hash belongs. 
+    // If bucket_count() is 0, it must always return 0.
     std::size_t bucket_for_hash(std::size_t hash) const noexcept;
     
     // Return the number of buckets that should be used on next growth
     std::size_t next_bucket_count() const;
     
-    // Maximum number of buckets supported by the policy
+    // Return the maximum number of buckets supported by the policy.
     std::size_t max_bucket_count() const;
+    
+    // Reset the growth policy as if it was created with a bucket count of 0.
+    // After a clear, the policy must always return 0 when bucket_for_hash is called.
+    void clear() noexcept;
 }
 ```
 

--- a/tests/custom_allocator_tests.cpp
+++ b/tests/custom_allocator_tests.cpp
@@ -128,19 +128,19 @@ bool operator!=(const custom_allocator<T>&, const custom_allocator<U>&) {
 BOOST_AUTO_TEST_SUITE(test_custom_allocator)
 
 BOOST_AUTO_TEST_CASE(test_custom_allocator_1) {
-//         nb_global_new = 0;
-        nb_custom_allocs = 0;
-        
-        tsl::sparse_map<int, int, std::hash<int>, std::equal_to<int>, 
-                        custom_allocator<std::pair<int, int>>> map;
-        
-        const int nb_elements = 10000;
-        for(int i = 0; i < nb_elements; i++) {
-            map.insert({i, i*2});
-        }
-        
-        BOOST_CHECK_NE(nb_custom_allocs, 0);
-//         BOOST_CHECK_EQUAL(nb_global_new, 0);
+//    nb_global_new = 0;
+    nb_custom_allocs = 0;
+    
+    tsl::sparse_map<int, int, std::hash<int>, std::equal_to<int>, 
+                    custom_allocator<std::pair<int, int>>> map;
+    
+    const int nb_elements = 10000;
+    for(int i = 0; i < nb_elements; i++) {
+        map.insert({i, i*2});
+    }
+    
+    BOOST_CHECK_NE(nb_custom_allocs, 0);
+//    BOOST_CHECK_EQUAL(nb_global_new, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/policy_tests.cpp
+++ b/tests/policy_tests.cpp
@@ -49,15 +49,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_policy, Policy, test_types) {
     std::size_t bucket_count = 0;
     Policy policy(bucket_count);
     
+    BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+    BOOST_CHECK_EQUAL(bucket_count, 0);
+    
     try {
         while(true) {
+            const std::size_t previous_bucket_count = bucket_count;
+            
             bucket_count = policy.next_bucket_count();
             policy = Policy(bucket_count);
+            
+            BOOST_CHECK_EQUAL(policy.bucket_for_hash(0), 0);
+            BOOST_CHECK(bucket_count > previous_bucket_count);
         }
     }
     catch(const std::length_error& ) {
         exception_thrown = true;
-        BOOST_CHECK_EQUAL(bucket_count, policy.max_bucket_count());
     }
     
     BOOST_CHECK(exception_thrown);

--- a/tests/sparse_map_tests.cpp
+++ b/tests/sparse_map_tests.cpp
@@ -733,7 +733,8 @@ BOOST_AUTO_TEST_CASE(test_use_after_move_operator) {
     
     const std::size_t nb_values = 100;
     HMap map = utils::get_filled_hash_map<HMap>(nb_values);
-    HMap map_move = std::move(map);
+    HMap map_move(0);
+    map_move = std::move(map);
     
     
     BOOST_CHECK(map == (HMap()));

--- a/tests/sparse_map_tests.cpp
+++ b/tests/sparse_map_tests.cpp
@@ -101,7 +101,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_insert, HMap, test_types) {
     using key_t = typename HMap::key_type; using value_t = typename HMap:: mapped_type;
     
     const std::size_t nb_values = 1000;
-    HMap map;
+    HMap map(0);
+    BOOST_CHECK_EQUAL(map.bucket_count(), 0);
+    
     typename HMap::iterator it;
     bool inserted;
     
@@ -704,6 +706,49 @@ BOOST_AUTO_TEST_CASE(test_copy_constructor_operator) {
     BOOST_CHECK(map_copy == map_copy3);
 }
 
+BOOST_AUTO_TEST_CASE(test_use_after_move_constructor) {
+    using HMap = tsl::sparse_map<std::string, move_only_test>;
+    
+    const std::size_t nb_values = 100;
+    HMap map = utils::get_filled_hash_map<HMap>(nb_values);
+    HMap map_move(std::move(map));
+    
+    
+    BOOST_CHECK(map == (HMap()));
+    BOOST_CHECK_EQUAL(map.size(), 0);
+    BOOST_CHECK_EQUAL(map.bucket_count(), 0);
+    BOOST_CHECK_EQUAL(map.erase("a"), 0);
+    BOOST_CHECK(map.find("a") == map.end());
+    
+    for(std::size_t i = 0; i < nb_values; i++) {
+        map.insert({utils::get_key<std::string>(i), utils::get_value<move_only_test>(i)});
+    }
+    
+    BOOST_CHECK_EQUAL(map.size(), nb_values);
+    BOOST_CHECK(map == map_move);
+}
+
+BOOST_AUTO_TEST_CASE(test_use_after_move_operator) {
+    using HMap = tsl::sparse_map<std::string, move_only_test>;
+    
+    const std::size_t nb_values = 100;
+    HMap map = utils::get_filled_hash_map<HMap>(nb_values);
+    HMap map_move = std::move(map);
+    
+    
+    BOOST_CHECK(map == (HMap()));
+    BOOST_CHECK_EQUAL(map.size(), 0);
+    BOOST_CHECK_EQUAL(map.bucket_count(), 0);
+    BOOST_CHECK_EQUAL(map.erase("a"), 0);
+    BOOST_CHECK(map.find("a") == map.end());
+    
+    for(std::size_t i = 0; i < nb_values; i++) {
+        map.insert({utils::get_key<std::string>(i), utils::get_value<move_only_test>(i)});
+    }
+    
+    BOOST_CHECK_EQUAL(map.size(), nb_values);
+    BOOST_CHECK(map == map_move);
+}
 
 
 /**
@@ -762,6 +807,12 @@ BOOST_AUTO_TEST_CASE(test_swap) {
     
     BOOST_CHECK(map == (tsl::sparse_map<std::int64_t, std::int64_t>{{4, 40}, {5, 50}}));
     BOOST_CHECK(map2 == (tsl::sparse_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}}));
+    
+    map.insert({6, 60});
+    map2.insert({4, 40});
+    
+    BOOST_CHECK(map == (tsl::sparse_map<std::int64_t, std::int64_t>{{4, 40}, {5, 50}, {6, 60}}));
+    BOOST_CHECK(map2 == (tsl::sparse_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}, {4, 40}}));
 }
 
 
@@ -924,6 +975,7 @@ BOOST_AUTO_TEST_CASE(test_heterogeneous_lookups) {
 BOOST_AUTO_TEST_CASE(test_empty_map) {
     tsl::sparse_map<std::string, int> map(0);
     
+    BOOST_CHECK_EQUAL(map.bucket_count(), 0);
     BOOST_CHECK_EQUAL(map.size(), 0);
     BOOST_CHECK(map.empty());
     
@@ -953,7 +1005,7 @@ BOOST_AUTO_TEST_CASE(test_empty_map) {
  * Test precalculated hash
  */
 BOOST_AUTO_TEST_CASE(test_precalculated_hash) {
-    tsl::sparse_map<int, int, std::hash<int>> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}, {5, -5}, {6, -6}};
+    tsl::sparse_map<int, int> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}, {5, -5}, {6, -6}};
     const tsl::sparse_map<int, int> map_const = map;
     
     /**
@@ -983,6 +1035,10 @@ BOOST_AUTO_TEST_CASE(test_precalculated_hash) {
     auto it_range = map.equal_range(3, map.hash_function()(3));
     BOOST_REQUIRE_EQUAL(std::distance(it_range.first, it_range.second), 1);
     BOOST_CHECK_EQUAL(it_range.first->second, -3);
+    
+    auto it_range_const = map_const.equal_range(3, map_const.hash_function()(3));
+    BOOST_REQUIRE_EQUAL(std::distance(it_range_const.first, it_range_const.second), 1);
+    BOOST_CHECK_EQUAL(it_range_const.first->second, -3);
     
     /**
      * erase

--- a/tests/sparse_set_tests.cpp
+++ b/tests/sparse_set_tests.cpp
@@ -100,12 +100,20 @@ BOOST_AUTO_TEST_CASE(test_compare) {
     const tsl::sparse_set<std::string> set1_2 = {"e", "c", "b", "a", "d"};
     const tsl::sparse_set<std::string> set2_1 = {"e", "c", "b", "a", "d", "f"};
     const tsl::sparse_set<std::string> set3_1 = {"e", "c", "b", "a"};
+    const tsl::sparse_set<std::string> set4_1 = {};
+    const tsl::sparse_set<std::string> set4_2 = {};
     
     BOOST_CHECK(set1_1 == set1_2);
     BOOST_CHECK(set1_2 == set1_1);
     
+    BOOST_CHECK(set4_1 == set4_2);
+    BOOST_CHECK(set4_2 == set4_1);
+    
     BOOST_CHECK(set1_1 != set2_1);
     BOOST_CHECK(set2_1 != set1_1);
+    
+    BOOST_CHECK(set1_1 != set4_1);
+    BOOST_CHECK(set4_1 != set1_1);
     
     BOOST_CHECK(set1_1 != set3_1);
     BOOST_CHECK(set3_1 != set1_1);

--- a/tsl/sparse_growth_policy.h
+++ b/tsl/sparse_growth_policy.h
@@ -51,29 +51,34 @@ public:
     /**
      * Called on the hash table creation and on rehash. The number of buckets for the table is passed in parameter.
      * This number is a minimum, the policy may update this value with a higher value if needed (but not lower).
+     *
+     * If 0 is given, min_bucket_count_in_out must still be 0 after the policy creation and
+     * bucket_for_hash must always return 0 in this case.
      */
     explicit power_of_two_growth_policy(std::size_t& min_bucket_count_in_out) {
         if(min_bucket_count_in_out > max_bucket_count()) {
             throw std::length_error("The hash table exceeds its maxmimum size.");
         }
         
-        static_assert(MIN_BUCKETS_SIZE > 0, "MIN_BUCKETS_SIZE must be > 0.");
-        const std::size_t min_bucket_count = MIN_BUCKETS_SIZE;
-        
-        min_bucket_count_in_out = std::max(min_bucket_count, min_bucket_count_in_out);
-        min_bucket_count_in_out = round_up_to_power_of_two(min_bucket_count_in_out);
-        m_mask = min_bucket_count_in_out - 1;
+        if(min_bucket_count_in_out > 0) {
+            min_bucket_count_in_out = round_up_to_power_of_two(min_bucket_count_in_out);
+            m_mask = min_bucket_count_in_out - 1;
+        }
+        else {
+            m_mask = 0;
+        }
     }
     
     /**
-     * Return the bucket [0, bucket_count()) to which the hash belongs.
+     * Return the bucket [0, bucket_count()) to which the hash belongs. 
+     * If bucket_count() is 0, it must always return 0.
      */
     std::size_t bucket_for_hash(std::size_t hash) const noexcept {
         return hash & m_mask;
     }
     
     /**
-     * Return the bucket count to use when the bucket array grows on rehash.
+     * Return the number of buckets that should be used on next growth.
      */
     std::size_t next_bucket_count() const {
         if((m_mask + 1) > max_bucket_count() / GrowthFactor) {
@@ -89,6 +94,14 @@ public:
     std::size_t max_bucket_count() const {
         // Largest power of two.
         return (std::numeric_limits<std::size_t>::max() / 2) + 1;
+    }
+    
+    /**
+     * Reset the growth policy as if it was created with a bucket count of 0.
+     * After a clear, the policy must always return 0 when bucket_for_hash is called.
+     */
+    void clear() noexcept {
+        m_mask = 0;
     }
     
 private:
@@ -114,7 +127,6 @@ private:
     }
     
 protected:
-    static const std::size_t MIN_BUCKETS_SIZE = 2;
     static_assert(is_power_of_two(GrowthFactor) && GrowthFactor >= 2, "GrowthFactor must be a power of two >= 2.");
     
     std::size_t m_mask;
@@ -133,23 +145,24 @@ public:
             throw std::length_error("The hash table exceeds its maxmimum size.");
         }
         
-        static_assert(MIN_BUCKETS_SIZE > 0, "MIN_BUCKETS_SIZE must be > 0.");
-        const std::size_t min_bucket_count = MIN_BUCKETS_SIZE;
-        
-        min_bucket_count_in_out = std::max(min_bucket_count, min_bucket_count_in_out);
-        m_bucket_count = min_bucket_count_in_out;
+        if(min_bucket_count_in_out > 0) {
+            m_mod = min_bucket_count_in_out;
+        }
+        else {
+            m_mod = 1;
+        }
     }
     
     std::size_t bucket_for_hash(std::size_t hash) const noexcept {
-        return hash % m_bucket_count;
+        return hash % m_mod;
     }
     
     std::size_t next_bucket_count() const {
-        if(m_bucket_count == max_bucket_count()) {
+        if(m_mod == max_bucket_count()) {
             throw std::length_error("The hash table exceeds its maxmimum size.");
         }
         
-        const double next_bucket_count = std::ceil(double(m_bucket_count) * REHASH_SIZE_MULTIPLICATION_FACTOR);
+        const double next_bucket_count = std::ceil(double(m_mod) * REHASH_SIZE_MULTIPLICATION_FACTOR);
         if(!std::isnormal(next_bucket_count)) {
             throw std::length_error("The hash table exceeds its maxmimum size.");
         }
@@ -166,8 +179,11 @@ public:
         return MAX_BUCKET_COUNT;
     }
     
+    void clear() noexcept {
+        m_mod = 1;
+    }
+    
 private:
-    static const std::size_t MIN_BUCKETS_SIZE = 2;
     static constexpr double REHASH_SIZE_MULTIPLICATION_FACTOR = 1.0 * GrowthFactor::num / GrowthFactor::den;
     static const std::size_t MAX_BUCKET_COUNT = 
             std::size_t(double(
@@ -176,18 +192,18 @@ private:
             
     static_assert(REHASH_SIZE_MULTIPLICATION_FACTOR >= 1.1, "Growth factor should be >= 1.1.");
     
-    std::size_t m_bucket_count;
+    std::size_t m_mod;
 };
 
 
 
 namespace detail {
 
-static constexpr const std::array<std::size_t, 39> PRIMES = {{
-    5ul, 17ul, 29ul, 37ul, 53ul, 67ul, 79ul, 97ul, 131ul, 193ul, 257ul, 389ul, 521ul, 769ul, 1031ul, 1543ul, 2053ul, 
-    3079ul, 6151ul, 12289ul, 24593ul, 49157ul, 98317ul, 196613ul, 393241ul, 786433ul, 1572869ul, 3145739ul, 
-    6291469ul, 12582917ul, 25165843ul, 50331653ul, 100663319ul, 201326611ul, 402653189ul, 805306457ul, 
-    1610612741ul, 3221225473ul, 4294967291ul
+static constexpr const std::array<std::size_t, 40> PRIMES = {{
+    1ul, 5ul, 17ul, 29ul, 37ul, 53ul, 67ul, 79ul, 97ul, 131ul, 193ul, 257ul, 389ul, 521ul, 769ul, 1031ul, 
+    1543ul, 2053ul, 3079ul, 6151ul, 12289ul, 24593ul, 49157ul, 98317ul, 196613ul, 393241ul, 786433ul, 
+    1572869ul, 3145739ul, 6291469ul, 12582917ul, 25165843ul, 50331653ul, 100663319ul, 201326611ul, 
+    402653189ul, 805306457ul, 1610612741ul, 3221225473ul, 4294967291ul
 }};
 
 template<unsigned int IPrime>
@@ -195,11 +211,11 @@ static constexpr std::size_t mod(std::size_t hash) { return hash % PRIMES[IPrime
 
 // MOD_PRIME[iprime](hash) returns hash % PRIMES[iprime]. This table allows for faster modulo as the
 // compiler can optimize the modulo code better with a constant known at the compilation.
-static constexpr const std::array<std::size_t(*)(std::size_t), 39> MOD_PRIME = {{ 
+static constexpr const std::array<std::size_t(*)(std::size_t), 40> MOD_PRIME = {{ 
     &mod<0>, &mod<1>, &mod<2>, &mod<3>, &mod<4>, &mod<5>, &mod<6>, &mod<7>, &mod<8>, &mod<9>, &mod<10>, 
     &mod<11>, &mod<12>, &mod<13>, &mod<14>, &mod<15>, &mod<16>, &mod<17>, &mod<18>, &mod<19>, &mod<20>, 
     &mod<21>, &mod<22>, &mod<23>, &mod<24>, &mod<25>, &mod<26>, &mod<27>, &mod<28>, &mod<29>, &mod<30>, 
-    &mod<31>, &mod<32>, &mod<33>, &mod<34>, &mod<35>, &mod<36>, &mod<37> , &mod<38>
+    &mod<31>, &mod<32>, &mod<33>, &mod<34>, &mod<35>, &mod<36>, &mod<37> , &mod<38>, &mod<39>
 }};
 
 }
@@ -238,7 +254,12 @@ public:
         }
         
         m_iprime = static_cast<unsigned int>(std::distance(detail::PRIMES.begin(), it_prime));
-        min_bucket_count_in_out = *it_prime;
+        if(min_bucket_count_in_out > 0) {
+            min_bucket_count_in_out = *it_prime;
+        }
+        else {
+            min_bucket_count_in_out = 0;
+        }
     }
     
     std::size_t bucket_for_hash(std::size_t hash) const noexcept {
@@ -255,6 +276,10 @@ public:
     
     std::size_t max_bucket_count() const {
         return detail::PRIMES.back();
+    }
+    
+    void clear() noexcept {
+        m_iprime = 0;
     }
     
 private:

--- a/tsl/sparse_hash.h
+++ b/tsl/sparse_hash.h
@@ -1495,7 +1495,10 @@ public:
      * Hash policy 
      */
     float load_factor() const {
-        tsl_assert(bucket_count() > 0);
+        if(bucket_count() == 0) {
+            return 0;
+        }
+        
         return float(m_nb_elements)/float(bucket_count());
     }
     
@@ -1555,7 +1558,11 @@ private:
     }
     
     size_type bucket_for_hash(std::size_t hash) const {
-        return GrowthPolicy::bucket_for_hash(hash);
+        const std::size_t bucket = GrowthPolicy::bucket_for_hash(hash);
+        tsl_assert(sparse_array::sparse_ibucket(bucket) < m_sparse_buckets.size() || 
+                   (bucket == 0 && m_sparse_buckets.empty()));
+        
+        return bucket;        
     }
     
     template<class U = GrowthPolicy, typename std::enable_if<is_power_of_two_policy<U>::value>::type* = nullptr>

--- a/tsl/sparse_hash.h
+++ b/tsl/sparse_hash.h
@@ -1136,7 +1136,14 @@ public:
         m_load_threshold_clear_deleted = other.m_load_threshold_clear_deleted;
         m_max_load_factor = other.m_max_load_factor;
         
-        other.clear();
+        other.GrowthPolicy::clear();
+        other.m_sparse_buckets.clear();
+        other.m_first_or_empty_sparse_bucket = static_empty_sparse_bucket_ptr();
+        other.m_bucket_count = 0;
+        other.m_nb_elements = 0;
+        other.m_nb_deleted_buckets = 0;
+        other.m_load_threshold_rehash = 0;
+        other.m_load_threshold_clear_deleted = 0;
         
         return *this;
     }

--- a/tsl/sparse_hash.h
+++ b/tsl/sparse_hash.h
@@ -338,6 +338,11 @@ public:
     {
     }
     
+    explicit sparse_array(bool last_bucket) noexcept: m_values(nullptr), m_bitmap_vals(0), m_bitmap_deleted_vals(0), 
+                                                      m_nb_elements(0), m_capacity(0), m_last_array(last_bucket)
+    {
+    }
+    
     sparse_array(const sparse_array& other, Allocator& alloc): 
                              m_values(nullptr), m_bitmap_vals(other.m_bitmap_vals), 
                              m_bitmap_deleted_vals(other.m_bitmap_deleted_vals), 
@@ -829,6 +834,9 @@ private:
                   std::is_copy_constructible<ValueType>::value, 
                   "Key, and T if present, must be nothrow move constructible and/or copy constructible.");
 
+    static_assert(noexcept(std::declval<GrowthPolicy>().bucket_for_hash(std::size_t(0))), "GrowthPolicy::bucket_for_hash must be noexcept.");
+    static_assert(noexcept(std::declval<GrowthPolicy>().clear()), "GrowthPolicy::clear must be noexcept.");
+    
 public:   
     template<bool IsConst>
     class sparse_iterator;
@@ -971,10 +979,12 @@ public:
                 const Hash& hash,
                 const KeyEqual& equal,
                 const Allocator& alloc,
-                float max_load_factor): Allocator(alloc), Hash(hash), KeyEqual(equal),
-                                        // We need a non-zero bucket_count
-                                        GrowthPolicy(bucket_count == 0?++bucket_count:bucket_count),
+                float max_load_factor): Allocator(alloc), 
+                                        Hash(hash), 
+                                        KeyEqual(equal),
+                                        GrowthPolicy(bucket_count),
                                         m_sparse_buckets(alloc), 
+                                        m_first_or_empty_sparse_bucket(static_empty_sparse_bucket_ptr()),
                                         m_bucket_count(bucket_count),
                                         m_nb_elements(0),
                                         m_nb_deleted_buckets(0)
@@ -983,21 +993,26 @@ public:
             throw std::length_error("The map exceeds its maxmimum size.");
         }
         
-        /*
-         * We can't use the `vector(size_type count, const Allocator& alloc)` constructor
-         * as it's only available in C++14 and we need to support C++11. We thus must resize after using
-         * the `vector(const Allocator& alloc)` constructor.
-         * 
-         * We can't use `vector(size_type count, const T& value, const Allocator& alloc)` as it requires the
-         * value T to be copyable.
-         */
-        const size_type nb_sparse_buckets = 
-                std::max(size_type(1), 
-                         sparse_array::sparse_ibucket(tsl::detail_sparse_hash::round_up_to_power_of_two(bucket_count)));
-                   
-        m_sparse_buckets.resize(nb_sparse_buckets);
-        m_sparse_buckets.back().set_as_last();
-        
+        if(m_bucket_count > 0) {
+            /*
+            * We can't use the `vector(size_type count, const Allocator& alloc)` constructor
+            * as it's only available in C++14 and we need to support C++11. We thus must resize after using
+            * the `vector(const Allocator& alloc)` constructor.
+            * 
+            * We can't use `vector(size_type count, const T& value, const Allocator& alloc)` as it requires the
+            * value T to be copyable.
+            */
+            const size_type nb_sparse_buckets = 
+                    std::max(size_type(1), 
+                             sparse_array::sparse_ibucket(tsl::detail_sparse_hash::round_up_to_power_of_two(bucket_count)));
+                    
+            m_sparse_buckets.resize(nb_sparse_buckets);
+            m_first_or_empty_sparse_bucket = m_sparse_buckets.data();
+            
+            tsl_assert(!m_sparse_buckets.empty());
+            m_sparse_buckets.back().set_as_last();
+        }
+            
         
         this->max_load_factor(max_load_factor);
     }
@@ -1019,11 +1034,8 @@ public:
                     m_load_threshold_clear_deleted(other.m_load_threshold_clear_deleted),
                     m_max_load_factor(other.m_max_load_factor)
     {
-        m_sparse_buckets.reserve(other.m_sparse_buckets.size());
-        for(const auto& bucket: other.m_sparse_buckets) {
-            m_sparse_buckets.emplace_back(bucket, static_cast<Allocator&>(*this));
-        }
-        tsl_assert(!m_sparse_buckets.empty() && m_sparse_buckets.back().last());
+        copy_buckets_from(other),
+        m_first_or_empty_sparse_bucket = m_sparse_buckets.data();
     }
     
     sparse_hash(sparse_hash&& other) noexcept(std::is_nothrow_move_constructible<Allocator>::value &&
@@ -1036,6 +1048,8 @@ public:
                                             KeyEqual(std::move(other)),
                                             GrowthPolicy(std::move(other)),
                                             m_sparse_buckets(std::move(other.m_sparse_buckets)),
+                                            m_first_or_empty_sparse_bucket(m_sparse_buckets.empty()?static_empty_sparse_bucket_ptr():
+                                                                                                    m_sparse_buckets.data()),
                                             m_bucket_count(other.m_bucket_count),
                                             m_nb_elements(other.m_nb_elements),
                                             m_nb_deleted_buckets(other.m_nb_deleted_buckets),
@@ -1043,7 +1057,14 @@ public:
                                             m_load_threshold_clear_deleted(other.m_load_threshold_clear_deleted),
                                             m_max_load_factor(other.m_max_load_factor)
     {
-        other.clear();
+        other.GrowthPolicy::clear();
+        other.m_sparse_buckets.clear();
+        other.m_first_or_empty_sparse_bucket = static_empty_sparse_bucket_ptr();
+        other.m_bucket_count = 0;
+        other.m_nb_elements = 0;
+        other.m_nb_deleted_buckets = 0;
+        other.m_load_threshold_rehash = 0;
+        other.m_load_threshold_clear_deleted = 0;
     }
     
     sparse_hash& operator=(const sparse_hash& other) {
@@ -1070,11 +1091,9 @@ public:
                 }
             }
             
-            m_sparse_buckets.reserve(other.m_sparse_buckets.size());
-            for(const auto& bucket: other.m_sparse_buckets) {
-                m_sparse_buckets.emplace_back(bucket, static_cast<Allocator&>(*this));
-            }
-            tsl_assert(!m_sparse_buckets.empty() && m_sparse_buckets.back().last());
+            copy_buckets_from(other);
+            m_first_or_empty_sparse_bucket = m_sparse_buckets.empty()?static_empty_sparse_bucket_ptr():
+                                                                      m_sparse_buckets.data();
             
             
             m_bucket_count = other.m_bucket_count;
@@ -1096,17 +1115,17 @@ public:
             m_sparse_buckets = std::move(other.m_sparse_buckets);
         }
         else if(static_cast<Allocator&>(*this) != static_cast<Allocator&>(other)) {
-            m_sparse_buckets.reserve(other.m_sparse_buckets.size());
-            for(auto&& bucket: other.m_sparse_buckets) {
-                m_sparse_buckets.emplace_back(std::move(bucket), static_cast<Allocator&>(*this));
-            }
-            tsl_assert(!m_sparse_buckets.empty() && m_sparse_buckets.back().last());
+            move_buckets_from(std::move(other));
         }
         else {
             static_cast<Allocator&>(*this) = std::move(static_cast<Allocator&>(other));
             m_sparse_buckets = std::move(other.m_sparse_buckets);
         }
 
+            
+        m_first_or_empty_sparse_bucket = m_sparse_buckets.empty()?static_empty_sparse_bucket_ptr():
+                                                                  m_sparse_buckets.data();
+        
         static_cast<Hash&>(*this) = std::move(static_cast<Hash&>(other));
         static_cast<KeyEqual&>(*this) = std::move(static_cast<KeyEqual&>(other));
         static_cast<GrowthPolicy&>(*this) = std::move(static_cast<GrowthPolicy&>(other));
@@ -1354,6 +1373,7 @@ public:
         swap(static_cast<KeyEqual&>(*this), static_cast<KeyEqual&>(other));
         swap(static_cast<GrowthPolicy&>(*this), static_cast<GrowthPolicy&>(other));
         swap(m_sparse_buckets, other.m_sparse_buckets);
+        swap(m_first_or_empty_sparse_bucket, other.m_first_or_empty_sparse_bucket);
         swap(m_bucket_count, other.m_bucket_count);
         swap(m_nb_elements, other.m_nb_elements);
         swap(m_nb_deleted_buckets, other.m_nb_deleted_buckets);
@@ -1565,6 +1585,39 @@ private:
     }
     
     
+    // TODO encapsulate m_sparse_buckets to avoid the managing the allocator
+    void copy_buckets_from(const sparse_hash& other) {
+        m_sparse_buckets.reserve(other.m_sparse_buckets.size());
+        
+        try {
+            for(const auto& bucket: other.m_sparse_buckets) {
+                m_sparse_buckets.emplace_back(bucket, static_cast<Allocator&>(*this));
+            }
+        }
+        catch(...) {
+            clear();
+            throw;
+        }        
+        
+        tsl_assert(m_sparse_buckets.empty() || m_sparse_buckets.back().last());
+    }
+    
+    void move_buckets_from(sparse_hash&& other) {
+        m_sparse_buckets.reserve(other.m_sparse_buckets.size());
+        
+        try {
+            for(auto&& bucket: other.m_sparse_buckets) {
+                m_sparse_buckets.emplace_back(std::move(bucket), static_cast<Allocator&>(*this));
+            }
+        }
+        catch(...) {
+            clear();
+            throw;
+        }        
+        
+        tsl_assert(m_sparse_buckets.empty() || m_sparse_buckets.back().last());
+    }
+    
     
     template<class K, class... Args>
     std::pair<iterator, bool> insert_impl(const K& key, Args&&... value_type_args) {
@@ -1574,6 +1627,7 @@ private:
         else if(size() + m_nb_deleted_buckets >= m_load_threshold_clear_deleted) {
             clear_deleted_buckets();
         }
+        tsl_assert(!m_sparse_buckets.empty());
         
         /**
          * We must insert the value in the first empty or deleted bucket we find. If we first find a 
@@ -1653,17 +1707,17 @@ private:
             const std::size_t sparse_ibucket = sparse_array::sparse_ibucket(ibucket);
             const auto index_in_sparse_bucket = sparse_array::index_in_sparse_bucket(ibucket);
         
-            if(m_sparse_buckets[sparse_ibucket].has_value(index_in_sparse_bucket)) {
-                auto value_it = m_sparse_buckets[sparse_ibucket].value(index_in_sparse_bucket);
+            if((m_first_or_empty_sparse_bucket + sparse_ibucket)->has_value(index_in_sparse_bucket)) {
+                auto value_it = (m_first_or_empty_sparse_bucket + sparse_ibucket)->value(index_in_sparse_bucket);
                 if(compare_keys(key, KeySelect()(*value_it))) {
-                    m_sparse_buckets[sparse_ibucket].erase(*this, value_it, index_in_sparse_bucket);
+                    (m_first_or_empty_sparse_bucket + sparse_ibucket)->erase(*this, value_it, index_in_sparse_bucket);
                     m_nb_elements--;
                     m_nb_deleted_buckets++;
                     
                     return 1;
                 }
             }
-            else if(!m_sparse_buckets[sparse_ibucket].has_deleted_value(index_in_sparse_bucket) || probe >= m_bucket_count) {
+            else if(!(m_first_or_empty_sparse_bucket + sparse_ibucket)->has_deleted_value(index_in_sparse_bucket) || probe >= m_bucket_count) {
                 return 0;
             }
             
@@ -1688,13 +1742,13 @@ private:
             const std::size_t sparse_ibucket = sparse_array::sparse_ibucket(ibucket);
             const auto index_in_sparse_bucket = sparse_array::index_in_sparse_bucket(ibucket);
         
-            if(m_sparse_buckets[sparse_ibucket].has_value(index_in_sparse_bucket)) {
-                auto value_it = m_sparse_buckets[sparse_ibucket].value(index_in_sparse_bucket);
+            if((m_first_or_empty_sparse_bucket + sparse_ibucket)->has_value(index_in_sparse_bucket)) {
+                auto value_it = (m_first_or_empty_sparse_bucket + sparse_ibucket)->value(index_in_sparse_bucket);
                 if(compare_keys(key, KeySelect()(*value_it))) {
                     return const_iterator(m_sparse_buckets.cbegin() + sparse_ibucket, value_it);
                 }
             }
-            else if(!m_sparse_buckets[sparse_ibucket].has_deleted_value(index_in_sparse_bucket) || probe >= m_bucket_count) {
+            else if(!(m_first_or_empty_sparse_bucket + sparse_ibucket)->has_deleted_value(index_in_sparse_bucket) || probe >= m_bucket_count) {
                 return cend();
             }
             
@@ -1760,16 +1814,16 @@ private:
             std::size_t sparse_ibucket = sparse_array::sparse_ibucket(ibucket);
             auto index_in_sparse_bucket = sparse_array::index_in_sparse_bucket(ibucket);
         
-            if(!m_sparse_buckets[sparse_ibucket].has_value(index_in_sparse_bucket)) {
-                m_sparse_buckets[sparse_ibucket].set(*this, index_in_sparse_bucket, 
-                                                     std::forward<K>(key_value));
+            if(!(m_first_or_empty_sparse_bucket + sparse_ibucket)->has_value(index_in_sparse_bucket)) {
+                (m_first_or_empty_sparse_bucket + sparse_ibucket)->set(*this, index_in_sparse_bucket, 
+                                                                       std::forward<K>(key_value));
                 m_nb_elements++;
                 
                 return;
             }
             else {
                 tsl_assert(!compare_keys(key, 
-                                         KeySelect()(*m_sparse_buckets[sparse_ibucket].value(index_in_sparse_bucket))));
+                                         KeySelect()(*(m_first_or_empty_sparse_bucket + sparse_ibucket)->value(index_in_sparse_bucket))));
             }
             
             probe++;
@@ -1781,8 +1835,24 @@ public:
     static const size_type DEFAULT_INIT_BUCKETS_SIZE = sparse_array::DEFAULT_INIT_BUCKETS_SIZE;
     static constexpr float DEFAULT_MAX_LOAD_FACTOR = 0.5f;
     
+    /**
+     * Return an always valid pointer to an static empty bucket_entry with last_bucket() == true.
+     */            
+    sparse_array* static_empty_sparse_bucket_ptr() {
+        static sparse_array empty_sparse_bucket(true);
+        return &empty_sparse_bucket;
+    }
+    
 private:
     sparse_buckets_container m_sparse_buckets;
+    
+    /**
+     * Points to m_sparse_buckets.data() if !m_sparse_buckets.empty() otherwise points to 
+     * static_empty_sparse_bucket_ptr. This variable is useful to avoid the cost of checking  
+     * if m_sparse_buckets is empty when trying to find an element.
+     */
+    sparse_array* m_first_or_empty_sparse_bucket;
+    
     size_type m_bucket_count;
     size_type m_nb_elements;
     size_type m_nb_deleted_buckets;


### PR DESCRIPTION
Correct moved state, a moved `tsl::sparse_map` or `tsl::sparse_set` can now still be used after a move. Previously the map ended up in a invalid state after a move but the standard mandates that a moved object should be in a valid (but unspecified) state so that it can still be used after a move.

The following code will now work:
```c++
tsl::sparse_set<int> set = {0, 1, 2, 3, 4};
tsl::sparse_set<int> set2 = std::move(set);
    
set.erase(0);
set.find(0);
set.insert(0);
```