### PR TITLE
 Add support for efficient serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A **benchmark** of `tsl::sparse_map` against other hash maps may be found [here]
 - Support for heterogeneous lookups allowing the usage of `find` with a type different than `Key` (e.g. if you have a map that uses `std::unique_ptr<foo>` as key, you can use a `foo*` or a `std::uintptr_t` as key parameter to `find` without constructing a `std::unique_ptr<foo>`, see [example](#heterogeneous-lookups)).
 - No need to reserve any sentinel value from the keys.
 - If the hash is known before a lookup, it is possible to pass it as parameter to speed-up the lookup (see `precalculated_hash` parameter in [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html)).
+- Support for efficient serialization and deserialization (see [example](#serialization) and the `serialize/deserialize` methods in the [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html) for details).
 - Possibility to control the balance between insertion speed and memory usage with the `Sparsity` template parameter. A high sparsity means less memory but longer insertion times, and vice-versa for low sparsity. The default medium sparsity offers a good compromise (see [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html#details) for details). For reference, with simple 64 bits integers as keys and values, a low sparsity offers ~15% faster insertions times but uses ~12% more memory. Nothing change regarding lookup speed.
 - API closely similar to `std::unordered_map` and `std::unordered_set`.
 
@@ -259,6 +260,127 @@ int main() {
     // 2004
     std::cout << map2.at(4) << std::endl;
 }
+```
+
+#### Serialization
+
+The library provides an efficient way to serialize and deserialize a map or a set so that it can be saved to a file or send through the network.
+To do so, it requires the user to provide a function object for both serialization and deserialization.
+
+```c++
+struct serializer {
+    // Must support the following types for U: std::uint64_t, float 
+    // and std::pair<Key, T> if a map is used or Key for a set.
+    void operator()(const U& value);
+};
+```
+
+```c++
+struct deserializer {
+    // Must support the following types for U: std::uint64_t, float 
+    // and std::pair<Key, T> if a map is used or Key for a set.
+    U operator()();
+};
+```
+
+Note that the implementation leaves binary compatibilty (endianness, float binary representation, size of int, ...) of the types it serializes/deserializes in the hands of the provided function objects if compatibilty is required.
+
+More details regarding the `serialize` and `deserialize` methods can be found in the [API](https://tessil.github.io/sparse-map/classtsl_1_1sparse__map.html).
+
+```c++
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <type_traits>
+#include <tsl/sparse_map.h>
+
+
+class serializer {
+public:
+    serializer(const char* file_name) {
+        m_ostream.exceptions(m_ostream.badbit | m_ostream.failbit);
+        m_ostream.open(file_name);
+    }
+    
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void operator()(const T& value) {
+        m_ostream.write(reinterpret_cast<const char*>(&value), sizeof(T));
+    }
+    
+    void operator()(const std::pair<std::int64_t, std::int64_t>& value) {
+        (*this)(value.first);
+        (*this)(value.second);
+    }
+
+private:
+    std::ofstream m_ostream;
+};
+
+class deserializer {
+public:
+    deserializer(const char* file_name) {
+        m_istream.exceptions(m_istream.badbit | m_istream.failbit | m_istream.eofbit);
+        m_istream.open(file_name);
+    }
+    
+    template<class T>
+    T operator()() {
+        T value;
+        deserialize(value);
+        
+        return value;
+    }
+    
+private:
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void deserialize(T& value) {
+        m_istream.read(reinterpret_cast<char*>(&value), sizeof(T));
+    }
+    
+    void deserialize(std::pair<std::int64_t, std::int64_t>& value) {
+        deserialize(value.first);
+        deserialize(value.second);
+    }
+
+private:
+    std::ifstream m_istream;
+};
+
+
+int main() {
+    const tsl::sparse_map<std::int64_t, std::int64_t> map = {{1, -1}, {2, -2}, {3, -3}, {4, -4}};
+    
+    
+    const char* file_name = "sparse_map.data";
+    {
+        serializer serial(file_name);
+        map.serialize(serial);
+    }
+    
+    {
+        deserializer dserial(file_name);
+        auto map_deserialized = tsl::sparse_map<std::int64_t, std::int64_t>::deserialize(dserial);
+        
+        assert(map == map_deserialized);
+    }
+    
+    {
+        deserializer dserial(file_name);
+        
+        /**
+         * If the serialized and deserialized map are hash compatibles (see conditions in API), 
+         * setting the argument to true speed-up the deserialization process as we don't have 
+         * to recalculate the hash of each key. We also know how much space each bucket needs.
+         */
+        const bool hash_compatible = true;
+        auto map_deserialized = 
+            tsl::sparse_map<std::int64_t, std::int64_t>::deserialize(dserial, hash_compatible);
+        
+        assert(map == map_deserialized);
+    }
+} 
 ```
 
 ### License

--- a/include/tsl/sparse_hash.h
+++ b/include/tsl/sparse_hash.h
@@ -373,8 +373,8 @@ public:
     {
     }
     
-    sparse_array(size_type capacity, Allocator& alloc) noexcept: m_values(nullptr), m_bitmap_vals(0), m_bitmap_deleted_vals(0), 
-                                                                 m_nb_elements(0), m_capacity(capacity), m_last_array(false)
+    sparse_array(size_type capacity, Allocator& alloc): m_values(nullptr), m_bitmap_vals(0), m_bitmap_deleted_vals(0), 
+                                                        m_nb_elements(0), m_capacity(capacity), m_last_array(false)
     {
         if(m_capacity > 0) {
             m_values = alloc.allocate(m_capacity);

--- a/include/tsl/sparse_hash.h
+++ b/include/tsl/sparse_hash.h
@@ -1974,7 +1974,7 @@ private:
         tsl_sh_assert(nb_sparse_buckets > 0);
         m_sparse_buckets.reserve(static_cast<size_type>(nb_sparse_buckets));
         
-        for(slz_size_type ibucket = 0; ibucket < nb_sparse_buckets; ibucket++) {
+        for(std::size_t ibucket = 0; ibucket < static_cast<size_type>(nb_sparse_buckets); ibucket++) {
             const slz_size_type sparse_bucket_size = deserialize_value<slz_size_type>(deserializer, istream);
             m_sparse_buckets.emplace_back(static_cast<typename sparse_array::size_type>(sparse_bucket_size), 
                                           static_cast<Allocator&>(*this));

--- a/include/tsl/sparse_hash.h
+++ b/include/tsl/sparse_hash.h
@@ -1896,7 +1896,7 @@ private:
             const slz_size_type sparse_bucket_size = bucket.size();
             serializer(sparse_bucket_size, ostream);
             
-            size_type value_offset = 0;
+            typename sparse_array::size_type value_offset = 0;
             for(const value_type& value: bucket) {
                 const slz_size_type value_index = bucket.offset_to_index(value_offset);
                 serializer(value_index, ostream);

--- a/include/tsl/sparse_map.h
+++ b/include/tsl/sparse_map.h
@@ -637,12 +637,38 @@ public:
     iterator mutable_iterator(const_iterator pos) {
         return m_ht.mutable_iterator(pos);
     }
-
+    
+    /**
+     * Serialize the map through the `serializer` parameter.
+     * 
+     * The `serializer` parameter must be a function object that supports the following call:
+     *  - `void operator()(const U& value);` where the types `std::uint64_t`, `float` and `std::pair<Key, T>` must be supported for U.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, ...) of the types it serializes
+     * in the hands of the `Serializer` function object if compatibilty is required.
+     */
     template<class Serializer>
     void serialize(Serializer& serializer) const {
         m_ht.serialize(serializer);
     }
-    
+
+    /**
+     * Deserialize a previouly serialized map through the `deserializer` parameter.
+     * 
+     * The `deserializer` parameter must be a function object that supports the following calls:
+     *  - `template<typename U> U operator()();` where the types `std::uint64_t`, `float` and `std::pair<Key, T>` must be supported for U.
+     * 
+     * If the deserialized hash map type is hash compatible with the serialized map, the deserialization process can be
+     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and GrowthPolicy must behave the 
+     * same way than the ones used on the serialized map. The `std::size_t` must also be of the same size as the one on the platform used
+     * to serialize the map. If these criteria are not met, the behaviour is undefined with `hash_compatible` sets to true, .
+     * 
+     * The behaviour is undefined if the type `Key` and `T` of the `sparse_map` are not the same as the
+     * types used during serialization.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, size of int, ...) of the types it 
+     * deserializes in the hands of the `Deserializer` function object if compatibilty is required.
+     */
     template<class Deserializer>
     static sparse_map deserialize(Deserializer& deserializer, bool hash_compatible = false) {
         sparse_map map(0);

--- a/include/tsl/sparse_map.h
+++ b/include/tsl/sparse_map.h
@@ -637,21 +637,19 @@ public:
     iterator mutable_iterator(const_iterator pos) {
         return m_ht.mutable_iterator(pos);
     }
-    
-    template<class Serializer, class OutputStream>
-    void serialize(const Serializer& serializer, OutputStream& writer) {
-        m_ht.serialize(serializer, writer);
+
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        m_ht.serialize(serializer);
     }
     
-    template<class Deserializer, class InputStream>
-    static sparse_map deserialize(const Deserializer& deserializer, InputStream& istream, bool hash_compatible = false) {
+    template<class Deserializer>
+    static sparse_map deserialize(Deserializer& deserializer, bool hash_compatible = false) {
         sparse_map map(0);
-        map.m_ht.deserialize(deserializer, istream, hash_compatible);
-        
+        map.m_ht.deserialize(deserializer, hash_compatible);
+
         return map;
     }
-    
-    
     
     friend bool operator==(const sparse_map& lhs, const sparse_map& rhs) {
         if(lhs.size() != rhs.size()) {

--- a/include/tsl/sparse_map.h
+++ b/include/tsl/sparse_map.h
@@ -644,9 +644,9 @@ public:
     }
     
     template<class Deserializer>
-    static sparse_map deserialize(Deserializer& deserializer) {
+    static sparse_map deserialize(Deserializer& deserializer, bool hash_compatible = false) {
         sparse_map map(0);
-        map.m_ht.deserialize(deserializer);
+        map.m_ht.deserialize(deserializer, hash_compatible);
         
         return map;
     }

--- a/include/tsl/sparse_map.h
+++ b/include/tsl/sparse_map.h
@@ -638,15 +638,15 @@ public:
         return m_ht.mutable_iterator(pos);
     }
     
-    template<class Serializer>
-    void serialize(Serializer& serializer) {
-        m_ht.serialize(serializer);
+    template<class Serializer, class OutputStream>
+    void serialize(const Serializer& serializer, OutputStream& writer) {
+        m_ht.serialize(serializer, writer);
     }
     
-    template<class Deserializer>
-    static sparse_map deserialize(Deserializer& deserializer, bool hash_compatible = false) {
+    template<class Deserializer, class InputStream>
+    static sparse_map deserialize(const Deserializer& deserializer, InputStream& istream, bool hash_compatible = false) {
         sparse_map map(0);
-        map.m_ht.deserialize(deserializer, hash_compatible);
+        map.m_ht.deserialize(deserializer, istream, hash_compatible);
         
         return map;
     }

--- a/include/tsl/sparse_map.h
+++ b/include/tsl/sparse_map.h
@@ -638,6 +638,21 @@ public:
         return m_ht.mutable_iterator(pos);
     }
     
+    template<class Serializer>
+    void serialize(Serializer& serializer) {
+        m_ht.serialize(serializer);
+    }
+    
+    template<class Deserializer>
+    static sparse_map deserialize(Deserializer& deserializer) {
+        sparse_map map(0);
+        map.m_ht.deserialize(deserializer);
+        
+        return map;
+    }
+    
+    
+    
     friend bool operator==(const sparse_map& lhs, const sparse_map& rhs) {
         if(lhs.size() != rhs.size()) {
             return false;

--- a/include/tsl/sparse_set.h
+++ b/include/tsl/sparse_set.h
@@ -502,15 +502,15 @@ public:
         return m_ht.mutable_iterator(pos);
     }
     
-    template<class Serializer>
-    void serialize(Serializer& serializer) {
-        m_ht.serialize(serializer);
+    template<class Serializer, class OutputStream>
+    void serialize(const Serializer& serializer, OutputStream& ostream) {
+        m_ht.serialize(serializer, ostream);
     }
     
-    template<class Deserializer>
-    static sparse_set deserialize(Deserializer& deserializer, bool hash_compatible = false) {
+    template<class Deserializer, class InputStream>
+    static sparse_set deserialize(const Deserializer& deserializer, InputStream& istream, bool hash_compatible = false) {
         sparse_set set(0);
-        set.m_ht.deserialize(deserializer, hash_compatible);
+        set.m_ht.deserialize(deserializer, istream, hash_compatible);
         
         return set;
     }

--- a/include/tsl/sparse_set.h
+++ b/include/tsl/sparse_set.h
@@ -501,12 +501,38 @@ public:
     iterator mutable_iterator(const_iterator pos) {
         return m_ht.mutable_iterator(pos);
     }
-
+    
+    /**
+     * Serialize the set through the `serializer` parameter.
+     * 
+     * The `serializer` parameter must be a function object that supports the following call:
+     *  - `void operator()(const U& value);` where the types `std::uint64_t`, `float` and `Key` must be supported for U.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, ...) of the types it serializes
+     * in the hands of the `Serializer` function object if compatibilty is required.
+     */
     template<class Serializer>
     void serialize(Serializer& serializer) const {
         m_ht.serialize(serializer);
     }
-    
+
+    /**
+     * Deserialize a previouly serialized set through the `deserializer` parameter.
+     * 
+     * The `deserializer` parameter must be a function object that supports the following calls:
+     *  - `template<typename U> U operator()();` where the types `std::uint64_t`, `float` and `Key` must be supported for U.
+     * 
+     * If the deserialized hash set type is hash compatible with the serialized set, the deserialization process can be
+     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and GrowthPolicy must behave the 
+     * same way than the ones used on the serialized set. The `std::size_t` must also be of the same size as the one on the platform used
+     * to serialize the set. If these criteria are not met, the behaviour is undefined with `hash_compatible` sets to true, .
+     * 
+     * The behaviour is undefined if the type `Key` of the `sparse_set` is not the same as the
+     * type used during serialization.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, size of int, ...) of the types it 
+     * deserializes in the hands of the `Deserializer` function object if compatibilty is required.
+     */
     template<class Deserializer>
     static sparse_set deserialize(Deserializer& deserializer, bool hash_compatible = false) {
         sparse_set set(0);

--- a/include/tsl/sparse_set.h
+++ b/include/tsl/sparse_set.h
@@ -502,6 +502,21 @@ public:
         return m_ht.mutable_iterator(pos);
     }
     
+    template<class Serializer>
+    void serialize(Serializer& serializer) {
+        m_ht.serialize(serializer);
+    }
+    
+    template<class Deserializer>
+    static sparse_set deserialize(Deserializer& deserializer) {
+        sparse_set set(0);
+        set.m_ht.deserialize(deserializer);
+        
+        return set;
+    }
+    
+    
+    
     friend bool operator==(const sparse_set& lhs, const sparse_set& rhs) {
         if(lhs.size() != rhs.size()) {
             return false;

--- a/include/tsl/sparse_set.h
+++ b/include/tsl/sparse_set.h
@@ -501,21 +501,19 @@ public:
     iterator mutable_iterator(const_iterator pos) {
         return m_ht.mutable_iterator(pos);
     }
-    
-    template<class Serializer, class OutputStream>
-    void serialize(const Serializer& serializer, OutputStream& ostream) {
-        m_ht.serialize(serializer, ostream);
+
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        m_ht.serialize(serializer);
     }
     
-    template<class Deserializer, class InputStream>
-    static sparse_set deserialize(const Deserializer& deserializer, InputStream& istream, bool hash_compatible = false) {
+    template<class Deserializer>
+    static sparse_set deserialize(Deserializer& deserializer, bool hash_compatible = false) {
         sparse_set set(0);
-        set.m_ht.deserialize(deserializer, istream, hash_compatible);
-        
+        set.m_ht.deserialize(deserializer, hash_compatible);
+
         return set;
     }
-    
-    
     
     friend bool operator==(const sparse_set& lhs, const sparse_set& rhs) {
         if(lhs.size() != rhs.size()) {

--- a/include/tsl/sparse_set.h
+++ b/include/tsl/sparse_set.h
@@ -508,9 +508,9 @@ public:
     }
     
     template<class Deserializer>
-    static sparse_set deserialize(Deserializer& deserializer) {
+    static sparse_set deserialize(Deserializer& deserializer, bool hash_compatible = false) {
         sparse_set set(0);
-        set.m_ht.deserialize(deserializer);
+        set.m_ht.deserialize(deserializer, hash_compatible);
         
         return set;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,6 @@ endif()
 find_package(Boost 1.54.0 REQUIRED COMPONENTS unit_test_framework)
 target_link_libraries(tsl_sparse_map_tests PRIVATE Boost::unit_test_framework)   
 
-# tsl::hopscotch_map
+# tsl::sparse_map
 add_subdirectory(../ ${CMAKE_CURRENT_BINARY_DIR}/tsl)
 target_link_libraries(tsl_sparse_map_tests PRIVATE tsl::sparse_map)  

--- a/tests/sparse_map_tests.cpp
+++ b/tests/sparse_map_tests.cpp
@@ -31,7 +31,6 @@
 #include <functional>
 #include <iterator>
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <tuple>

--- a/tests/sparse_map_tests.cpp
+++ b/tests/sparse_map_tests.cpp
@@ -842,18 +842,16 @@ BOOST_AUTO_TEST_CASE(test_serialize_desearialize_empty_map) {
     buffer.exceptions(buffer.badbit | buffer.failbit | buffer.eofbit);
     
     tsl::sparse_map<move_only_test, std::string> empty_map(0);
-    serializer<std::stringstream> serializer(buffer);
-    empty_map.serialize(serializer);
+    empty_map.serialize(serializer(), buffer);
     
     
     
     
-    deserializer<std::stringstream> deserializer(buffer);
-    auto empty_map_deserialized = decltype(empty_map)::deserialize(deserializer, true);
+    auto empty_map_deserialized = decltype(empty_map)::deserialize(serializer(), buffer, true);
     BOOST_CHECK(empty_map_deserialized == empty_map);
     
     buffer.seekg(0);
-    empty_map_deserialized = decltype(empty_map)::deserialize(deserializer, false);
+    empty_map_deserialized = decltype(empty_map)::deserialize(serializer(), buffer, false);
     BOOST_CHECK(empty_map_deserialized == empty_map);
 }
 
@@ -876,18 +874,16 @@ BOOST_AUTO_TEST_CASE(test_serialize_desearialize_map) {
     }
     BOOST_CHECK_EQUAL(map.size(), nb_values);
     
-    serializer<std::stringstream> map_serializer(buffer);
-    map.serialize(map_serializer);
+    map.serialize(serializer(), buffer);
     
     
     
     
-    deserializer<std::stringstream> map_deserializer(buffer);
-    auto map_deserialized = decltype(map)::deserialize(map_deserializer, true);
+    auto map_deserialized = decltype(map)::deserialize(serializer(), buffer, true);
     BOOST_CHECK(map_deserialized == map);
     
     buffer.seekg(0);
-    map_deserialized = decltype(map)::deserialize(map_deserializer, false);
+    map_deserialized = decltype(map)::deserialize(serializer(), buffer, false);
     BOOST_CHECK(map_deserialized == map);
 }
 
@@ -912,13 +908,13 @@ BOOST_AUTO_TEST_CASE(test_serialize_desearialize_map_with_different_hash) {
     }
     BOOST_CHECK_EQUAL(map.size(), nb_values);
     
-    
-    serializer<std::stringstream> map_serializer(buffer);
-    map.serialize(map_serializer);
+    map.serialize(serializer(), buffer);
     
     
-    deserializer<std::stringstream> map_deserializer(buffer);
-    auto map_deserialized = tsl::sparse_map<std::string, move_only_test, hash_str_with_size>::deserialize(map_deserializer);
+    
+    
+    auto map_deserialized = 
+            tsl::sparse_map<std::string, move_only_test, hash_str_with_size>::deserialize(serializer(), buffer);
     
     BOOST_CHECK_EQUAL(map_deserialized.size(), map.size());
     for(const auto& val: map) {

--- a/tests/sparse_set_tests.cpp
+++ b/tests/sparse_set_tests.cpp
@@ -135,18 +135,16 @@ BOOST_AUTO_TEST_CASE(test_serialize_desearialize_empty_set) {
     buffer.exceptions(buffer.badbit | buffer.failbit | buffer.eofbit);
     
     tsl::sparse_set<move_only_test> empty_set(0);
-    serializer<std::stringstream> serializer(buffer);
-    empty_set.serialize(serializer);
+    empty_set.serialize(serializer(), buffer);
     
     
     
     
-    deserializer<std::stringstream> deserializer(buffer);
-    auto empty_set_deserialized = decltype(empty_set)::deserialize(deserializer, true);
+    auto empty_set_deserialized = decltype(empty_set)::deserialize(serializer(), buffer, true);
     BOOST_CHECK(empty_set_deserialized == empty_set);
     
     buffer.seekg(0);
-    empty_set_deserialized = decltype(empty_set)::deserialize(deserializer, false);
+    empty_set_deserialized = decltype(empty_set)::deserialize(serializer(), buffer, false);
     BOOST_CHECK(empty_set_deserialized == empty_set);
 }
 
@@ -169,18 +167,16 @@ BOOST_AUTO_TEST_CASE(test_serialize_desearialize_set) {
     }
     BOOST_CHECK_EQUAL(set.size(), nb_values);
     
-    serializer<std::stringstream> set_serializer(buffer);
-    set.serialize(set_serializer);
+    set.serialize(serializer(), buffer);
     
     
     
     
-    deserializer<std::stringstream> set_deserializer(buffer);
-    auto set_deserialized = decltype(set)::deserialize(set_deserializer, true);
+    auto set_deserialized = decltype(set)::deserialize(serializer(), buffer, true);
     BOOST_CHECK(set_deserialized == set);
     
     buffer.seekg(0);
-    set_deserialized = decltype(set)::deserialize(set_deserializer, false);
+    set_deserialized = decltype(set)::deserialize(serializer(), buffer, false);
     BOOST_CHECK(set_deserialized == set);
 }
 
@@ -205,13 +201,12 @@ BOOST_AUTO_TEST_CASE(test_serialize_desearialize_set_with_different_hash) {
     }
     BOOST_CHECK_EQUAL(set.size(), nb_values);
     
-    
-    serializer<std::stringstream> set_serializer(buffer);
-    set.serialize(set_serializer);
+    set.serialize(serializer(), buffer);
     
     
-    deserializer<std::stringstream> set_deserializer(buffer);
-    auto set_deserialized = tsl::sparse_set<move_only_test, hash_str_with_size>::deserialize(set_deserializer);
+    
+    
+    auto set_deserialized = tsl::sparse_set<move_only_test, hash_str_with_size>::deserialize(serializer(), buffer);
     
     BOOST_CHECK_EQUAL(set_deserialized.size(), set.size());
     for(const auto& val: set) {

--- a/tests/sparse_set_tests.cpp
+++ b/tests/sparse_set_tests.cpp
@@ -30,7 +30,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -325,25 +325,25 @@ public:
     }
     
     template<typename T>
-    void serialize(const T& val) {
-        serialize_impl(val);
+    void operator()(const T& val) {
+        serialize(val);
     }
     
 private:   
-    void serialize_impl(const std::string& val) {
-        serialize_impl(static_cast<std::uint64_t>(val.size()));
+    void serialize(const std::string& val) {
+        serialize(static_cast<std::uint64_t>(val.size()));
         m_ostream.write(val.data(), val.size());
     }
     
-    void serialize_impl(const move_only_test& val) {
-        serialize_impl(val.value());
+    void serialize(const move_only_test& val) {
+        serialize(val.value());
     }
     
-    void serialize_impl(const std::uint64_t& val) {
+    void serialize(const std::uint64_t& val) {
         m_ostream.write(reinterpret_cast<const char*>(&val), sizeof(val));
     }
     
-    void serialize_impl(const float& val) {
+    void serialize(const float& val) {
         m_ostream.write(reinterpret_cast<const char*>(&val), sizeof(val));
     }
     
@@ -357,14 +357,14 @@ public:
     }
     
     template<typename T>
-    T deserialize() {
-        return deserialize_impl<T>();
+    T operator()() {
+        return deserialize<T>();
     }
     
 private:
     template<class T, typename std::enable_if<std::is_same<std::string, T>::value>::type* = nullptr>
-    std::string deserialize_impl() {
-        const std::uint64_t str_size = deserialize_impl<std::uint64_t>();
+    std::string deserialize() {
+        const std::uint64_t str_size = deserialize<std::uint64_t>();
         
         std::vector<char> chars(str_size);
         m_istream.read(chars.data(), str_size);
@@ -373,12 +373,12 @@ private:
     }
     
     template<class T, typename std::enable_if<std::is_same<move_only_test, T>::value>::type* = nullptr>
-    move_only_test deserialize_impl() {
-        return move_only_test(deserialize_impl<std::string>());
+    move_only_test deserialize() {
+        return move_only_test(deserialize<std::string>());
     }
     
     template<class T, typename std::enable_if<std::is_same<std::uint64_t, T>::value>::type* = nullptr>
-    std::uint64_t deserialize_impl() {
+    std::uint64_t deserialize() {
         std::uint64_t val;
         m_istream.read(reinterpret_cast<char*>(&val), sizeof(val));
         
@@ -386,7 +386,7 @@ private:
     }
     
     template<class T, typename std::enable_if<std::is_same<float, T>::value>::type* = nullptr>
-    float deserialize_impl() {
+    float deserialize() {
         float val;
         m_istream.read(reinterpret_cast<char*>(&val), sizeof(val));
         

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -31,6 +31,7 @@
 #include <functional>
 #include <memory>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <utility>
 

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -379,7 +379,7 @@ private:
     template<class T, class InputStream, 
              typename std::enable_if<std::is_same<std::string, T>::value>::type* = nullptr>
     T deserialize(InputStream& istream) const {
-        const std::uint64_t str_size = deserialize<std::uint64_t>(istream);
+        const std::size_t str_size = static_cast<std::size_t>(deserialize<std::uint64_t>(istream));
         
         std::vector<char> chars(str_size);
         istream.read(chars.data(), str_size);


### PR DESCRIPTION
This PR adds two new methods `template<class Serializer> void serialize(Serializer& serializer) const;` and `template<class Deserializer> static sparse_map deserialize(Deserializer& deserializer, bool hash_compatible = false);` to `tsl::sparse_(pg)_map/set`. 

They take advantage of the internals of the data structure to provide an efficient way to serialize/deserialize the structure.

Fix feature request #2.