### PR TITLE
Fix warning by adding "languages" to CMake project declaration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
+
+project(tsl-sparse-map VERSION 0.6.2 LANGUAGES CXX)
 include(GNUInstallDirs)
-
-
-project(tsl-sparse-map VERSION 0.6.2)
 
 add_library(sparse_map INTERFACE)
 # Use tsl::sparse_map as target, more consistent with other libraries conventions (Boost, Qt, ...)


### PR DESCRIPTION
With CMake 3.18:
```
CMake Warning (dev) at /usr/local/Cellar/cmake/3.18.4/share/cmake/Modules/GNUInstallDirs.cmake:225 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  CMakeLists.txt:2 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```