### PR TITLE
Fix serialization for small hashes

### DIFF
--- a/include/tsl/sparse_hash.h
+++ b/include/tsl/sparse_hash.h
@@ -2024,28 +2024,27 @@ private:
         const slz_size_type nb_elements = deserialize_value<slz_size_type>(deserializer);
         const slz_size_type nb_deleted_buckets = deserialize_value<slz_size_type>(deserializer);
         const float max_load_factor = deserialize_value<float>(deserializer);
-        
-        if(hash_compatible) {
-            // Set bucket count before recalculating load factors
-            m_bucket_count = numeric_cast<size_type>(bucket_count_ds, "Deserialized bucket_count is too big.");
-        }
 
-        
-        this->max_load_factor(max_load_factor);
-        
         if(bucket_count_ds == 0) {
+            this->max_load_factor(max_load_factor);
+
             tsl_sh_assert(nb_elements == 0 && nb_sparse_buckets == 0);
             return;
         }
-        
-        
+
+
         if(!hash_compatible) {
+            this->max_load_factor(max_load_factor);
+
             reserve(numeric_cast<size_type>(nb_elements, "Deserialized nb_elements is too big."));
             for(slz_size_type ibucket = 0; ibucket < nb_sparse_buckets; ibucket++) {
                 sparse_array::deserialize_values_into_sparse_hash(deserializer, *this);
             }
         }
         else {
+            m_bucket_count = numeric_cast<size_type>(bucket_count_ds, "Deserialized bucket_count is too big.");
+            this->max_load_factor(max_load_factor);
+
             GrowthPolicy::operator=(GrowthPolicy(m_bucket_count));
             // GrowthPolicy should not modify the bucket count we got from deserialization
             if(m_bucket_count != bucket_count_ds) {

--- a/include/tsl/sparse_hash.h
+++ b/include/tsl/sparse_hash.h
@@ -2025,6 +2025,11 @@ private:
         const slz_size_type nb_deleted_buckets = deserialize_value<slz_size_type>(deserializer);
         const float max_load_factor = deserialize_value<float>(deserializer);
         
+        if(hash_compatible) {
+            // Set bucket count before recalculating load factors
+            m_bucket_count = numeric_cast<size_type>(bucket_count_ds, "Deserialized bucket_count is too big.");
+        }
+
         
         this->max_load_factor(max_load_factor);
         
@@ -2041,8 +2046,6 @@ private:
             }
         }
         else {
-            m_bucket_count = numeric_cast<size_type>(bucket_count_ds, "Deserialized bucket_count is too big.");
-            
             GrowthPolicy::operator=(GrowthPolicy(m_bucket_count));
             // GrowthPolicy should not modify the bucket count we got from deserialization
             if(m_bucket_count != bucket_count_ds) {

--- a/tests/sparse_map_tests.cpp
+++ b/tests/sparse_map_tests.cpp
@@ -982,6 +982,9 @@ BOOST_AUTO_TEST_CASE(test_serialize_deserialize_empty) {
 }
 
 BOOST_AUTO_TEST_CASE(test_serialize_deserialize_few) {
+    // insert x values that fits into one sparse bucket; delete some values; serialize map; 
+    // deserialize in new map; check equal. for deserialization, test it with and without
+    // hash compatibility.
     const tsl::sparse_map<std::int64_t, std::int64_t> map{{10, 100}, {4, 14}, {9, 201}};
 
     serializer serial;

--- a/tests/sparse_map_tests.cpp
+++ b/tests/sparse_map_tests.cpp
@@ -981,6 +981,22 @@ BOOST_AUTO_TEST_CASE(test_serialize_deserialize_empty) {
     BOOST_CHECK(empty_map_deserialized == empty_map);
 }
 
+BOOST_AUTO_TEST_CASE(test_serialize_deserialize_few) {
+    const tsl::sparse_map<std::int64_t, std::int64_t> map{{10, 100}, {4, 14}, {9, 201}};
+
+    serializer serial;
+    map.serialize(serial);
+
+    deserializer dserial(serial.str());
+    auto map_deserialized = decltype(map)::deserialize(dserial, true);
+    BOOST_CHECK(map_deserialized == map);
+
+    deserializer dserial2(serial.str());
+    map_deserialized = decltype(map)::deserialize(dserial2, false);
+    BOOST_CHECK(map_deserialized == map);
+}
+
+
 BOOST_AUTO_TEST_CASE(test_serialize_deserialize) {
     // insert x values; delete some values; serialize map; deserialize in new map; check equal.
     // for deserialization, test it with and without hash compatibility.

--- a/tests/sparse_set_tests.cpp
+++ b/tests/sparse_set_tests.cpp
@@ -142,34 +142,60 @@ BOOST_AUTO_TEST_CASE(test_insert_pointer) {
 /**
  * serialize and deserialize
  */
+BOOST_AUTO_TEST_CASE(test_serialize_deserialize_reserve) {
+    // insert x values; delete some values; serialize set; deserialize in new
+    // set; check equal. for deserialization, test it with and without hash
+    // compatibility.
+    for(std::size_t nb_values : {0, 1, 3, 17, 1000}) {
+        tsl::sparse_set<move_only_test> set;
+        set.reserve(nb_values);
+        for(std::size_t i = 0; i < nb_values; i++) {
+            set.insert(utils::get_key<move_only_test>(i));
+        }
+
+
+        serializer serial;
+        set.serialize(serial);
+
+        deserializer dserial(serial.str());
+        auto set_deserialized = decltype(set)::deserialize(dserial, true);
+        BOOST_CHECK(set == set_deserialized);
+
+        deserializer dserial2(serial.str());
+        set_deserialized = decltype(set)::deserialize(dserial2, false);
+        BOOST_CHECK(set_deserialized == set);
+    }
+}
+
+    
 BOOST_AUTO_TEST_CASE(test_serialize_deserialize) {
-    // insert x values; delete some values; serialize set; deserialize in new set; check equal.
-    // for deserialization, test it with and without hash compatibility.
-    const std::size_t nb_values = 1000;
-    
-    
-    tsl::sparse_set<move_only_test> set;
-    for(std::size_t i = 0; i < nb_values + 40; i++) {
-        set.insert(utils::get_key<move_only_test>(i));
+    // insert x values; delete some values; serialize set; deserialize in new
+    // set; check equal. for deserialization, test it with and without hash
+    // compatibility.
+    for(std::size_t nb_values : {0, 1, 3, 17, 1000}) {
+        tsl::sparse_set<move_only_test> set;
+        for(std::size_t i = 0; i < nb_values + 40; i++) {
+            set.insert(utils::get_key<move_only_test>(i));
+        }
+
+        for(std::size_t i = nb_values; i < nb_values + 40; i++) {
+            set.erase(utils::get_key<move_only_test>(i));
+        }
+        BOOST_CHECK_EQUAL(set.size(), nb_values);
+
+
+
+        serializer serial;
+        set.serialize(serial);
+
+        deserializer dserial(serial.str());
+        auto set_deserialized = decltype(set)::deserialize(dserial, true);
+        BOOST_CHECK(set == set_deserialized);
+
+        deserializer dserial2(serial.str());
+        set_deserialized = decltype(set)::deserialize(dserial2, false);
+        BOOST_CHECK(set_deserialized == set);
     }
-    
-    for(std::size_t i = nb_values; i < nb_values + 40; i++) {
-        set.erase(utils::get_key<move_only_test>(i));
-    }
-    BOOST_CHECK_EQUAL(set.size(), nb_values);
-
-    
-    
-    serializer serial;
-    set.serialize(serial);
-
-    deserializer dserial(serial.str());
-    auto set_deserialized = decltype(set)::deserialize(dserial, true);
-    BOOST_CHECK(set == set_deserialized);
-
-    deserializer dserial2(serial.str());
-    set_deserialized = decltype(set)::deserialize(dserial2, false);
-    BOOST_CHECK(set_deserialized == set);
 }
 
 

--- a/tests/sparse_set_tests.cpp
+++ b/tests/sparse_set_tests.cpp
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * 
+ *
  * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -45,52 +45,52 @@ using test_types = boost::mpl::list<tsl::sparse_set<std::int64_t>,
                                     tsl::sparse_set<self_reference_member_test>,
                                     tsl::sparse_set<move_only_test>,
                                     tsl::sparse_pg_set<self_reference_member_test>,
-                                    tsl::sparse_set<move_only_test, 
+                                    tsl::sparse_set<move_only_test,
                                                     std::hash<move_only_test>,
-                                                    std::equal_to<move_only_test>, 
+                                                    std::equal_to<move_only_test>,
                                                     std::allocator<move_only_test>,
                                                     tsl::sh::prime_growth_policy>,
-                                    tsl::sparse_set<self_reference_member_test, 
+                                    tsl::sparse_set<self_reference_member_test,
                                                     std::hash<self_reference_member_test>,
-                                                    std::equal_to<self_reference_member_test>, 
+                                                    std::equal_to<self_reference_member_test>,
                                                     std::allocator<self_reference_member_test>,
                                                     tsl::sh::mod_growth_policy<>>,
-                                    tsl::sparse_set<move_only_test, 
+                                    tsl::sparse_set<move_only_test,
                                                     std::hash<move_only_test>,
-                                                    std::equal_to<move_only_test>, 
+                                                    std::equal_to<move_only_test>,
                                                     std::allocator<move_only_test>,
                                                     tsl::sh::mod_growth_policy<>>
                                     >;
-                                    
-                                    
-                                    
+
+
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_insert, HSet, test_types) {
     // insert x values, insert them again, check values
     using key_t = typename HSet::key_type;
-    
+
     const std::size_t nb_values = 1000;
     HSet set;
     typename HSet::iterator it;
     bool inserted;
-    
+
     for(std::size_t i = 0; i < nb_values; i++) {
         std::tie(it, inserted) = set.insert(utils::get_key<key_t>(i));
-        
+
         BOOST_CHECK_EQUAL(*it, utils::get_key<key_t>(i));
         BOOST_CHECK(inserted);
     }
     BOOST_CHECK_EQUAL(set.size(), nb_values);
-    
+
     for(std::size_t i = 0; i < nb_values; i++) {
         std::tie(it, inserted) = set.insert(utils::get_key<key_t>(i));
-        
+
         BOOST_CHECK_EQUAL(*it, utils::get_key<key_t>(i));
         BOOST_CHECK(!inserted);
     }
-    
+
     for(std::size_t i = 0; i < nb_values; i++) {
         it = set.find(utils::get_key<key_t>(i));
-        
+
         BOOST_CHECK_EQUAL(*it, utils::get_key<key_t>(i));
     }
 }
@@ -101,25 +101,25 @@ BOOST_AUTO_TEST_CASE(test_compare) {
     const tsl::sparse_set<std::string> set2 = {"e", "c", "b", "a", "d", "f"};
     const tsl::sparse_set<std::string> set3 = {"e", "c", "b", "a"};
     const tsl::sparse_set<std::string> set4 = {"a", "e", "d", "c", "z"};
-    
+
     BOOST_CHECK(set1 == set1_copy);
     BOOST_CHECK(set1_copy == set1);
-    
+
     BOOST_CHECK(set1 != set2);
     BOOST_CHECK(set2 != set1);
-    
+
     BOOST_CHECK(set1 != set3);
     BOOST_CHECK(set3 != set1);
-    
+
     BOOST_CHECK(set1 != set4);
     BOOST_CHECK(set4 != set1);
-    
+
     BOOST_CHECK(set2 != set3);
     BOOST_CHECK(set3 != set2);
-    
+
     BOOST_CHECK(set2 != set4);
     BOOST_CHECK(set4 != set2);
-    
+
     BOOST_CHECK(set3 != set4);
     BOOST_CHECK(set4 != set3);
 }
@@ -138,14 +138,12 @@ BOOST_AUTO_TEST_CASE(test_insert_pointer) {
 }
 
 
-    
+
 /**
  * serialize and deserialize
  */
 BOOST_AUTO_TEST_CASE(test_serialize_deserialize_reserve) {
-    // insert x values; delete some values; serialize set; deserialize in new
-    // set; check equal. for deserialization, test it with and without hash
-    // compatibility.
+    // Insert a number of values without intermediate resizes.
     for(std::size_t nb_values : {0, 1, 3, 17, 1000}) {
         tsl::sparse_set<move_only_test> set;
         set.reserve(nb_values);
@@ -167,7 +165,7 @@ BOOST_AUTO_TEST_CASE(test_serialize_deserialize_reserve) {
     }
 }
 
-    
+
 BOOST_AUTO_TEST_CASE(test_serialize_deserialize) {
     // insert x values; delete some values; serialize set; deserialize in new
     // set; check equal. for deserialization, test it with and without hash

--- a/tests/sparse_set_tests.cpp
+++ b/tests/sparse_set_tests.cpp
@@ -1,18 +1,18 @@
 /**
  * MIT License
- *
+ * 
  * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -45,52 +45,52 @@ using test_types = boost::mpl::list<tsl::sparse_set<std::int64_t>,
                                     tsl::sparse_set<self_reference_member_test>,
                                     tsl::sparse_set<move_only_test>,
                                     tsl::sparse_pg_set<self_reference_member_test>,
-                                    tsl::sparse_set<move_only_test,
+                                    tsl::sparse_set<move_only_test, 
                                                     std::hash<move_only_test>,
-                                                    std::equal_to<move_only_test>,
+                                                    std::equal_to<move_only_test>, 
                                                     std::allocator<move_only_test>,
                                                     tsl::sh::prime_growth_policy>,
-                                    tsl::sparse_set<self_reference_member_test,
+                                    tsl::sparse_set<self_reference_member_test, 
                                                     std::hash<self_reference_member_test>,
-                                                    std::equal_to<self_reference_member_test>,
+                                                    std::equal_to<self_reference_member_test>, 
                                                     std::allocator<self_reference_member_test>,
                                                     tsl::sh::mod_growth_policy<>>,
-                                    tsl::sparse_set<move_only_test,
+                                    tsl::sparse_set<move_only_test, 
                                                     std::hash<move_only_test>,
-                                                    std::equal_to<move_only_test>,
+                                                    std::equal_to<move_only_test>, 
                                                     std::allocator<move_only_test>,
                                                     tsl::sh::mod_growth_policy<>>
                                     >;
-
-
-
+                                    
+                                    
+                                    
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_insert, HSet, test_types) {
     // insert x values, insert them again, check values
     using key_t = typename HSet::key_type;
-
+    
     const std::size_t nb_values = 1000;
     HSet set;
     typename HSet::iterator it;
     bool inserted;
-
+    
     for(std::size_t i = 0; i < nb_values; i++) {
         std::tie(it, inserted) = set.insert(utils::get_key<key_t>(i));
-
+        
         BOOST_CHECK_EQUAL(*it, utils::get_key<key_t>(i));
         BOOST_CHECK(inserted);
     }
     BOOST_CHECK_EQUAL(set.size(), nb_values);
-
+    
     for(std::size_t i = 0; i < nb_values; i++) {
         std::tie(it, inserted) = set.insert(utils::get_key<key_t>(i));
-
+        
         BOOST_CHECK_EQUAL(*it, utils::get_key<key_t>(i));
         BOOST_CHECK(!inserted);
     }
-
+    
     for(std::size_t i = 0; i < nb_values; i++) {
         it = set.find(utils::get_key<key_t>(i));
-
+        
         BOOST_CHECK_EQUAL(*it, utils::get_key<key_t>(i));
     }
 }
@@ -101,25 +101,25 @@ BOOST_AUTO_TEST_CASE(test_compare) {
     const tsl::sparse_set<std::string> set2 = {"e", "c", "b", "a", "d", "f"};
     const tsl::sparse_set<std::string> set3 = {"e", "c", "b", "a"};
     const tsl::sparse_set<std::string> set4 = {"a", "e", "d", "c", "z"};
-
+    
     BOOST_CHECK(set1 == set1_copy);
     BOOST_CHECK(set1_copy == set1);
-
+    
     BOOST_CHECK(set1 != set2);
     BOOST_CHECK(set2 != set1);
-
+    
     BOOST_CHECK(set1 != set3);
     BOOST_CHECK(set3 != set1);
-
+    
     BOOST_CHECK(set1 != set4);
     BOOST_CHECK(set4 != set1);
-
+    
     BOOST_CHECK(set2 != set3);
     BOOST_CHECK(set3 != set2);
-
+    
     BOOST_CHECK(set2 != set4);
     BOOST_CHECK(set4 != set2);
-
+    
     BOOST_CHECK(set3 != set4);
     BOOST_CHECK(set4 != set3);
 }
@@ -143,7 +143,9 @@ BOOST_AUTO_TEST_CASE(test_insert_pointer) {
  * serialize and deserialize
  */
 BOOST_AUTO_TEST_CASE(test_serialize_deserialize_reserve) {
-    // Insert a number of values without intermediate resizes.
+    // insert x values values without intermediate resizes; serialize set; 
+    // deserialize in new set; check equal. for deserialization, 
+    // test it with and without hash compatibility.
     for(std::size_t nb_values : {0, 1, 3, 17, 1000}) {
         tsl::sparse_set<move_only_test> set;
         set.reserve(nb_values);


### PR DESCRIPTION
I identified and believe I've fixed two bugs in deserialization:
- Small sets weren't calculating the right number of sparse buckets. (I added a test for this)
- Fast serialization wasn't updating the load factor values correctly (I checked that it was broken earlier and fixed now using debug statements, but I didn't know how to add a reliable test for it).