### PR TITLE
fix const value return by emplace iterator

### DIFF
--- a/include/tsl/sparse_hash.h
+++ b/include/tsl/sparse_hash.h
@@ -1070,7 +1070,7 @@ class sparse_hash : private Allocator,
 
    public:
     using iterator_category = std::forward_iterator_tag;
-    using value_type = const typename sparse_hash::value_type;
+    using value_type = typename sparse_hash::value_type;
     using difference_type = std::ptrdiff_t;
     using reference = value_type &;
     using pointer = value_type *;

--- a/include/tsl/sparse_hash.h
+++ b/include/tsl/sparse_hash.h
@@ -1072,8 +1072,13 @@ class sparse_hash : private Allocator,
     using iterator_category = std::forward_iterator_tag;
     using value_type = typename sparse_hash::value_type;
     using difference_type = std::ptrdiff_t;
-    using reference = value_type &;
-    using pointer = value_type *;
+    using reference =
+        typename std::conditional<IsConst,
+                                  typename sparse_hash::const_reference,
+                                  typename sparse_hash::reference>::type;
+    using pointer =
+        typename std::conditional<IsConst, typename sparse_hash::const_pointer,
+                                  typename sparse_hash::pointer>::type;
 
     sparse_iterator() noexcept {}
 

--- a/include/tsl/sparse_map.h
+++ b/include/tsl/sparse_map.h
@@ -103,6 +103,15 @@ class sparse_map {
     key_type &operator()(std::pair<Key, T> &key_value) noexcept {
       return key_value.first;
     }
+
+    const key_type &operator()(
+        const std::pair<const Key, T> &key_value) const noexcept {
+      return key_value.first;
+    }
+
+    const key_type &operator()(std::pair<const Key, T> &key_value) noexcept {
+      return key_value.first;
+    }
   };
 
   class ValueSelect {
@@ -121,7 +130,8 @@ class sparse_map {
 
   using ht = detail_sparse_hash::sparse_hash<
       std::pair<Key, T>, KeySelect, ValueSelect, Hash, KeyEqual, Allocator,
-      GrowthPolicy, ExceptionSafety, Sparsity, tsl::sh::probing::quadratic>;
+      GrowthPolicy, ExceptionSafety, Sparsity, tsl::sh::probing::quadratic,
+      std::pair<const Key, T>>;
 
  public:
   using key_type = typename ht::key_type;

--- a/include/tsl/sparse_set.h
+++ b/include/tsl/sparse_set.h
@@ -100,10 +100,9 @@ class sparse_set {
     key_type &operator()(Key &key) noexcept { return key; }
   };
 
-  using ht =
-      detail_sparse_hash::sparse_hash<Key, KeySelect, void, Hash, KeyEqual,
-                                      Allocator, GrowthPolicy, ExceptionSafety,
-                                      Sparsity, tsl::sh::probing::quadratic>;
+  using ht = detail_sparse_hash::sparse_hash<
+      Key, KeySelect, void, Hash, KeyEqual, Allocator, GrowthPolicy,
+      ExceptionSafety, Sparsity, tsl::sh::probing::quadratic, Key>;
 
  public:
   using key_type = typename ht::key_type;


### PR DESCRIPTION
with const this code will not compile
tsl::sparse_map<uint32_t,uint32_t> spp;
const auto it=spp.emplace(1,1);
it.first->second=1;