### PR TITLE
Bump minimum cmake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(tsl-sparse-map VERSION 0.6.2 LANGUAGES CXX)
 include(GNUInstallDirs)


### PR DESCRIPTION
Bump version to get rid of warning with recent cmake versions. cmake 3.10 is more ~8 years old.

```
CMake Deprecation Warning at third_party/sparse-map/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```